### PR TITLE
Adjust packer storage

### DIFF
--- a/packer/builders/azure/image-ubuntu/provisioner.json
+++ b/packer/builders/azure/image-ubuntu/provisioner.json
@@ -2,20 +2,24 @@
   "variables": {
     "client_id": "{{env `ARM_CLIENT_ID`}}",
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+    "tenant_id": "{{env `ARM_TENANT_ID`}}"
   },
   "builders": [
     {
       "type": "azure-arm",
       "client_id": "{{user `client_id`}}",
       "client_secret": "{{user `client_secret`}}",
+      "tenant_id": "{{user `tenant_id`}}",
       "subscription_id": "{{user `subscription_id`}}",
+      "resource_group_name": "packer-images-resource-group",
+      "storage_account": "neowayimagesstorage",
+      "capture_container_name": "neowayimagescontainer",
+      "capture_name_prefix": "neoway-packer-image",
       "os_type": "Linux",
       "image_publisher": "Canonical",
       "image_offer": "UbuntuServer",
       "image_sku": "16.04-LTS",
-      "managed_image_resource_group_name": "packer-images-resource-group",
-      "managed_image_name": "ubuntu-neoway-image",
       "location": "eastus2",
       "vm_size": "Standard_DS2_v2"
     }

--- a/terraform/providers/azure/images-builder/builder-environment.tf
+++ b/terraform/providers/azure/images-builder/builder-environment.tf
@@ -6,7 +6,22 @@ terraform {
   required_version = "0.11.7"
 }
 
-resource "azurerm_resource_group" "packer-rg" {
+resource "azurerm_resource_group" "packer_rg" {
   name     = "${var.builder_resource_group_name}"
   location = "${var.location}"
+}
+
+resource "azurerm_storage_account" "packer_sa" {
+  name                     = "${var.builder_storage_account_name}"
+  resource_group_name      = "${azurerm_resource_group.packer_rg.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_container" "packer_sc" {
+  name                  = "${var.builder_storage_container_name}"
+  resource_group_name   = "${azurerm_resource_group.packer_rg.name}"
+  storage_account_name  = "${azurerm_storage_account.packer_sa.name}"
+  container_access_type = "private"
 }

--- a/terraform/providers/azure/images-builder/variables.tf
+++ b/terraform/providers/azure/images-builder/variables.tf
@@ -14,7 +14,15 @@ variable "builder_resource_group_name" {
 
 variable "builder_image_name" {
   description = "Image name provisioned by packer"
-  default     = "default-image-azure"
+  default     = "ubuntu-neoway-image"
+}
+
+variable "builder_storage_account_name" {
+  default = "neowayimagesstorage"
+}
+
+variable "builder_storage_container_name" {
+  default = "neowayimagescontainer"
 }
 
 # Tester variables
@@ -61,5 +69,5 @@ variable "tester_user" {
 
 variable "tester_vm_size" {
   description = "Azure vm size"
-  default     = "Standard_DS2_v2"
+  default     = "Standard_B1s"
 }


### PR DESCRIPTION
This adjustment was needed for Azure marketplace deployment method, accepting only VHDs from a storage account, with a disk URI, not from a resource group.