### PR TITLE
VHD adjust Azure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ terraform.tfstate
 #google-cloud
 account.json
 
+# azure
+manifest.json
+
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
   - mkdir keys
   - ssh-keygen -b 2048 -t rsa -f /home/travis/build/NeowayLabs/packer-images/keys/id_rsa -q -N ""
+  - chmod 777 /home/travis/build/NeowayLabs/packer-images/packer/builders/azure/image-ubuntu/
   - pip install docker-py
 script:
   - make setup

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ base-docker-run = docker run \
 	--env GCP_TOKEN \
 	--env TF_VAR_travis_build_id=$(TRAVIS_BUILD_ID) \
 	--env TRAVIS_BUILD_ID \
+	--env TF_VAR_vhd_url=`cat packer/builders/azure/image-ubuntu/manifest.json | jq -r '.builds[] | .artifact_id'` \
 	--rm \
 	--volume $(shell pwd):/packer-images \
 	$(docker_ssh_opts) \

--- a/packer/builders/azure/image-ubuntu/provisioner.json
+++ b/packer/builders/azure/image-ubuntu/provisioner.json
@@ -42,5 +42,12 @@
       "inline_shebang": "/bin/sh -x",
       "type": "shell"
     }
+  ],
+  "post-processors": [
+    {
+      "type": "manifest",
+      "output": "manifest.json",
+      "strip_path": true
+    }
   ]
 }

--- a/terraform/providers/azure/images-tester/tester-environment.tf
+++ b/terraform/providers/azure/images-tester/tester-environment.tf
@@ -60,9 +60,17 @@ resource "azurerm_network_interface" "tester_nic" {
 # Set image to terraform use on VM
 # This Custom Image already builded by packer
 
-data "azurerm_image" "tester_image" {
-  name                = "${var.builder_image_name}"
-  resource_group_name = "${var.builder_resource_group_name}"
+resource "azurerm_image" "tester_image" {
+  name                = "tester-image"
+  location            = "${var.location}"
+  resource_group_name = "packer-images-resource-group"
+
+  os_disk {
+    os_type  = "Linux"
+    os_state = "Generalized"
+    blob_uri = "${var.vhd_url}"
+    size_gb  = 30
+  }
 }
 
 # Create virutal machine
@@ -79,7 +87,7 @@ resource "azurerm_virtual_machine" "tester_vm" {
   delete_os_disk_on_termination = true
 
   storage_image_reference {
-    id = "${data.azurerm_image.tester_image.id}"
+    id = "${azurerm_image.tester_image.id}"
   }
 
   storage_os_disk {
@@ -92,7 +100,7 @@ resource "azurerm_virtual_machine" "tester_vm" {
   os_profile {
     admin_username = "${var.tester_user}"
     admin_password = ""
-    computer_name  = "${var.tester_vm_name}"
+    computer_name  = "${var.prefix}-vm"
   }
 
   os_profile_linux_config {
@@ -100,7 +108,7 @@ resource "azurerm_virtual_machine" "tester_vm" {
 
     ssh_keys {
       path     = "/home/${var.tester_user}/.ssh/authorized_keys"
-      key_data = "${file("/packer-images/keys/id_rsa.pub")}"
+      key_data = "${file("/home/packer/.ssh/id_rsa.pub")}"
     }
   }
 }

--- a/terraform/providers/azure/images-tester/tester-environment.tf
+++ b/terraform/providers/azure/images-tester/tester-environment.tf
@@ -108,7 +108,7 @@ resource "azurerm_virtual_machine" "tester_vm" {
 
     ssh_keys {
       path     = "/home/${var.tester_user}/.ssh/authorized_keys"
-      key_data = "${file("/home/packer/.ssh/id_rsa.pub")}"
+      key_data = "${file("/packer-images/keys/id_rsa.pub")}"
     }
   }
 }

--- a/terraform/providers/azure/images-tester/variables.tf
+++ b/terraform/providers/azure/images-tester/variables.tf
@@ -63,3 +63,8 @@ variable "tester_vm_size" {
   description = "Azure vm size"
   default     = "Standard_B1s"
 }
+
+variable "vhd_url" {
+  description = "VHD url created by packer"
+  default     = ""
+}


### PR DESCRIPTION
This Adjustment was created because the Azure don't know properly how to deal with a VHD for deploys VMs. The terraform now build a Image Disk from a VHD, using a output json with the informations, to build the tester-vm.