### PR TITLE
Remove pcp copilot from default image

### DIFF
--- a/ansible/default-playbook.yml
+++ b/ansible/default-playbook.yml
@@ -8,7 +8,6 @@
        - "packer"
 
    roles:
-      #- ansible-role-pcp
       - ansible-role-ubuntu-hardening
 
    tasks:

--- a/ansible/default-playbook.yml
+++ b/ansible/default-playbook.yml
@@ -8,7 +8,7 @@
        - "packer"
 
    roles:
-      - ansible-role-pcp
+      #- ansible-role-pcp
       - ansible-role-ubuntu-hardening
 
    tasks:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,7 +1,3 @@
 # ansible-hardening
 - src: https://github.com/NeowayLabs/ansible-role-ubuntu-hardening
   version: master
-
-# ansible-role-pcp
-- src: https://github.com/NeowayLabs/ansible-role-pcp
-  version: v1.0


### PR DESCRIPTION
This tool are creating issues with a bunch of logs at some VMs on infrastructure.

Because of this, at this time, we removed them from this repo, and add as an optional tool on automation project.
